### PR TITLE
Make missing proofs actually fail the workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check files in donations.yml
         uses: mikefarah/yq@v4.6.1
         with:
-          cmd: ls -la */donations.yml; for F in */donations.yml; do PROOFS="`yq e '.[].files' $F | cut -d' ' -f2`"; for PROOF in "$PROOFS"; do echo -n $PROOF; [ ! -f "$PROOF" ] && echo ' does not exist' && exit 1; echo ' exists'; done; done
+          cmd: ls -la */donations.yml; for F in */donations.yml; do PROOFS="`yq e '.[].files' $F | cut -d' ' -f2`"; for PROOF in $PROOFS; do echo -n $PROOF; [ ! -f "$PROOF" ] && echo ' does not exist' && exit 1; echo ' exists'; done; done
 
       - name: Create jsons out of donations.yml
         uses: mikefarah/yq@v4.6.1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check files in donations.yml
         uses: mikefarah/yq@v4.6.1
         with:
-          cmd: ls -la */donations.yml; for F in */donations.yml; do yq e '.[].files' $F | cut -d' ' -f2 | while read PROOF; do echo -n $PROOF; [ ! -f "$PROOF" ] && echo ' does not exist' && exit 1; echo ' exists'; done; done
+          cmd: ls -la */donations.yml; for F in */donations.yml; do PROOFS=`yq e '.[].files' $F | cut -d' ' -f2`; for PROOF in "$PROOFS"; do echo -n $PROOF; [ ! -f "$PROOF" ] && echo ' does not exist' && exit 1; echo ' exists'; done; done
 
       - name: Create jsons out of donations.yml
         uses: mikefarah/yq@v4.6.1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check files in donations.yml
         uses: mikefarah/yq@v4.6.1
         with:
-          cmd: ls -la */donations.yml; for F in */donations.yml; do PROOFS="`yq e '.[].files' $F | cut -d' ' -f2`"; for PROOF in $PROOFS; do echo -n $PROOF; [ ! -f "$PROOF" ] && echo ' does not exist' && exit 1; echo ' exists'; done; done
+          cmd: ls -la */donations.yml; for F in */donations.yml; do PROOFS="`yq e '.[].files' $F | cut -d' ' -f2`"; for PROOF in $PROOFS; do echo -n $PROOF; [ ! -f "$PROOF" ] && echo ' MISSING' && exit 1; echo ' exists'; done; done
 
       - name: Create jsons out of donations.yml
         uses: mikefarah/yq@v4.6.1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check files in donations.yml
         uses: mikefarah/yq@v4.6.1
         with:
-          cmd: ls -la */donations.yml; for F in */donations.yml; do PROOFS=`yq e '.[].files' $F | cut -d' ' -f2`; for PROOF in "$PROOFS"; do echo -n $PROOF; [ ! -f "$PROOF" ] && echo ' does not exist' && exit 1; echo ' exists'; done; done
+          cmd: ls -la */donations.yml; for F in */donations.yml; do PROOFS="`yq e '.[].files' $F | cut -d' ' -f2`"; for PROOF in "$PROOFS"; do echo -n $PROOF; [ ! -f "$PROOF" ] && echo ' does not exist' && exit 1; echo ' exists'; done; done
 
       - name: Create jsons out of donations.yml
         uses: mikefarah/yq@v4.6.1


### PR DESCRIPTION
Since the exit statement was inside a loop being fed through a pipe it was inside a subprocess. Now a missing file should kill the workflow correctly.